### PR TITLE
Comment out pay-all button.

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -27,7 +27,10 @@
         You owe: {{ unpaidAmount | async | currency:'NZD':true }}
       </md-card-content>
       <md-card-actions align="end">
-        <button md-button (click)="payAll()">PAY ALL</button>
+      <!-- Removing until we get it wired up to the backend.
+           Note: This button should mark all weeks paid EXCEPT the current week.
+                 Else people will likely prematurely pay for the current week before everyone has joined -->
+<!--         <button md-button (click)="payAll()">PAY ALL</button> -->
       </md-card-actions>
     </md-card>
 


### PR DESCRIPTION
This button is confusing people because they don't know what to do with an alert with a text box that says "Soon™"

Removing until we get an implementation which can actually mark all previous weeks as paid.