### PR TITLE
Fix facebook logout callback missing issue.

### DIFF
--- a/src/app/facebook/facebook.service.ts
+++ b/src/app/facebook/facebook.service.ts
@@ -40,6 +40,6 @@ export class FacebookService {
   }
 
   logout() {
-    FB.logout();
+    FB.logout((response) => {});
   }
 }


### PR DESCRIPTION
FB.logout was expecting a callback but we don't actually care about the response.